### PR TITLE
Check to has extension before add extension

### DIFF
--- a/lib/Twig/Environment.php
+++ b/lib/Twig/Environment.php
@@ -648,8 +648,10 @@ class Twig_Environment
 
     public function addExtension(Twig_ExtensionInterface $extension)
     {
-        $this->extensionSet->addExtension($extension);
-        $this->updateOptionsHash();
+        if (!$this->hasExtension(get_class($extension))) {
+            $this->extensionSet->addExtension($extension);
+            $this->updateOptionsHash();
+        }
     }
 
     /**


### PR DESCRIPTION
### Why
I has error in my symfony3 project.

`var/cache/prod/appProdProjectContainer.php`
```
[LogicException]                                                                                              
  Unable to register extension "Symfony\Bridge\Twig\Extension\LogoutUrlExtension" as it is already registered.
```

I wanted to fix in Symfony, but it is difficult. So I create this PR.